### PR TITLE
Fix TraceContext.end_span() call with invalid attributes parameter

### DIFF
--- a/src/compymac/local_harness.py
+++ b/src/compymac/local_harness.py
@@ -4940,9 +4940,6 @@ Permissions: {mode}"""
                 trace_ctx.end_span(
                     status=SpanStatus.OK,
                     output_artifact_hash=output_artifact_hash,
-                    attributes={
-                        "verification_warning": verification_result.failure_summary(),
-                    },
                 )
             else:
                 trace_ctx.end_span(


### PR DESCRIPTION
The end_span() method doesn't accept an 'attributes' parameter, causing crashes when verification warnings are logged. Removed the invalid parameter to fix the blocking bug in menu system testing.